### PR TITLE
GoogleTest should be compiled first

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,10 +20,9 @@ IF(UNIX)
 ENDIF(UNIX)
 
 
-
+add_subdirectory(googletest)
 add_subdirectory(src)
 add_subdirectory(app)
 add_subdirectory(lang)
-add_subdirectory(googletest)
 
 enable_testing()


### PR DESCRIPTION
André, um primeiro pull request:

Assim o google test é compilado primeiro e não dá erro de link num projeto recém clonado
